### PR TITLE
Support resque pool master process information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ erl_crash.dump
 worker_tracker-*.tar
 
 .elixir_ls
+
+.idea/

--- a/lib/worker_tracker/worker_instance/client.ex
+++ b/lib/worker_tracker/worker_instance/client.ex
@@ -12,6 +12,7 @@ defmodule WorkerTracker.WorkerInstance.Client do
     |> parse_resque_pool_masters(worker_instance)
     |> parse_active_workers(worker_instance)
     |> parse_waiting_workers(worker_instance)
+
     :ok
   end
 
@@ -41,10 +42,11 @@ defmodule WorkerTracker.WorkerInstance.Client do
   defp parse_resque_pool_masters(processes, %__MODULE__{} = worker_instance) do
     processes
     |> ProcessHelper.filter_and_transform_process_list(
-         "resque-pool-master",
-         &ResquePoolMasterProcess.parse_master_process/1
-       )
+      "resque-pool-master",
+      &ResquePoolMasterProcess.parse_master_process/1
+    )
     |> update_worker_registrations(worker_instance.name, "master")
+
     processes
   end
 
@@ -55,6 +57,7 @@ defmodule WorkerTracker.WorkerInstance.Client do
       &ActiveWorkerProcess.parse_worker_process/1
     )
     |> update_worker_registrations(worker_instance.name)
+
     processes
   end
 

--- a/lib/worker_tracker/worker_instance/client.ex
+++ b/lib/worker_tracker/worker_instance/client.ex
@@ -1,21 +1,23 @@
 defmodule WorkerTracker.WorkerInstance.Client do
-  defstruct name: "", active_workers: [], waiting_workers: []
+  defstruct name: "", active_workers: [], waiting_workers: [], resque_pool_masters: []
 
   alias WorkerTracker.WorkerInstance.ActiveWorkerProcess
   alias WorkerTracker.WorkerInstance.WaitingWorkerProcess
+  alias WorkerTracker.WorkerInstance.ResquePoolMasterProcess
   alias WorkerTracker.ProcessHelper
 
   def refresh_instance(%__MODULE__{} = worker_instance) do
     worker_instance
     |> get_all_processes()
+    |> parse_resque_pool_masters(worker_instance)
     |> parse_active_workers(worker_instance)
     |> parse_waiting_workers(worker_instance)
-
     :ok
   end
 
   def get_instance(%__MODULE__{} = worker_instance) do
     worker_instance
+    |> Map.put(:resque_pool_masters, retrieve_worker_registrations(worker_instance, "master"))
     |> Map.put(:active_workers, retrieve_worker_registrations(worker_instance))
     |> Map.put(:waiting_workers, retrieve_worker_registrations(worker_instance, "waiting"))
   end
@@ -36,6 +38,16 @@ defmodule WorkerTracker.WorkerInstance.Client do
     |> ProcessHelper.create_list_from_string()
   end
 
+  defp parse_resque_pool_masters(processes, %__MODULE__{} = worker_instance) do
+    processes
+    |> ProcessHelper.filter_and_transform_process_list(
+         "resque-pool-master",
+         &ResquePoolMasterProcess.parse_master_process/1
+       )
+    |> update_worker_registrations(worker_instance.name, "master")
+    processes
+  end
+
   defp parse_active_workers(processes, %__MODULE__{} = worker_instance) do
     processes
     |> ProcessHelper.filter_and_transform_process_list(
@@ -43,7 +55,6 @@ defmodule WorkerTracker.WorkerInstance.Client do
       &ActiveWorkerProcess.parse_worker_process/1
     )
     |> update_worker_registrations(worker_instance.name)
-
     processes
   end
 

--- a/lib/worker_tracker/worker_instance/resque_pool_master_process.ex
+++ b/lib/worker_tracker/worker_instance/resque_pool_master_process.ex
@@ -1,0 +1,67 @@
+defmodule WorkerTracker.WorkerInstance.ResquePoolMasterProcess do
+  defstruct(
+    owner: "",
+    pid: 0,
+    ppid: 0,
+    name: "",
+    managed_processes: []
+  )
+
+  alias __MODULE__
+  alias WorkerTracker.ProcessHelper
+
+  @doc ~S"""
+
+  Parses resque-pool-master process information from the given process string
+
+  ## Example
+
+      iex> process_string = deploy   12345 23456 23456 23456 11 03:20 ?        00:36:04 resque-pool-master[90c000d68d5ac6f9b8de937161187f50c5b60722]: managing [26033, 26042]
+      iex> WorkerTracker.WorkerInstance.ResquePoolMasterProcess.parse_master_process(process_string)
+      %WorkerTracker.WorkerInstance.ResquePoolMasterProcess{owner: "deploy", pid: 12345, ppid: 23456, name: resque-pool-master[90c000d68d5ac6f9b8de937161187f50c5b60722], managed_processes: [26033, 26042]}
+  """
+  def parse_master_process(process_string) do
+    process_string
+    |> ProcessHelper.process_fields(%ResquePoolMasterProcess{}, &build_master_process/2)
+  end
+
+  defp build_master_process({value, 0}, master_process) do
+    %{master_process | owner: value}
+  end
+
+  defp build_master_process({value, 1}, master_process) do
+    pid =
+      value
+      |> String.to_integer()
+
+    %{master_process | pid: pid}
+  end
+
+  defp build_master_process({value, 2}, master_process) do
+    ppid =
+      value
+      |> String.to_integer()
+
+    %{master_process | ppid: ppid}
+  end
+
+  defp build_master_process({value, 9}, master_process) do
+    name =
+      value
+      |> String.replace(~r/:/, "")
+
+    %{master_process | name: name}
+  end
+
+  defp build_master_process({value, index}, master_process) do
+    if index > 10 do
+      managed_pid =
+        value
+        |> String.replace(~r/[^\d]/,"")
+        |> String.to_integer
+      %{master_process | managed_processes: master_process.managed_processes ++ [managed_pid] }
+    else
+      master_process
+    end
+  end
+end

--- a/lib/worker_tracker/worker_instance/resque_pool_master_process.ex
+++ b/lib/worker_tracker/worker_instance/resque_pool_master_process.ex
@@ -57,9 +57,10 @@ defmodule WorkerTracker.WorkerInstance.ResquePoolMasterProcess do
     if index > 10 do
       managed_pid =
         value
-        |> String.replace(~r/[^\d]/,"")
-        |> String.to_integer
-      %{master_process | managed_processes: master_process.managed_processes ++ [managed_pid] }
+        |> String.replace(~r/[^\d]/, "")
+        |> String.to_integer()
+
+      %{master_process | managed_processes: master_process.managed_processes ++ [managed_pid]}
     else
       master_process
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule WorkerTracker.MixProject do
   def project do
     [
       app: :worker_tracker,
-      version: "0.3.0",
+      version: "0.4.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       description: description(),
@@ -36,7 +36,7 @@ defmodule WorkerTracker.MixProject do
 
   defp package() do
     [
-      maintainers: ["Jeff Gillis", "Spencer Gilbert", "Anthony Johnston"],
+      maintainers: ["Jeff Gillis", "Spencer Gilbert", "Anthony Johnston", "Venky Jeyanthilal"],
       files: ~w(config lib test .formatter.exs mix.exs README.md),
       licenses: ["MIT"],
       links: %{"GitHub" => "https://github.com/optoro/worker_tracker"}


### PR DESCRIPTION
We ran into an issue where multiple resque pool processes
were running on the same worker machine.
Adding support to look for the resque pool master process and
getting the list of processes managed by it.